### PR TITLE
Added support of both versions (v1, v2) of a spot WebSocket topics

### DIFF
--- a/ByBit.Net/Clients/SpotApi/BybitBaseSocketClientSpotStreams.cs
+++ b/ByBit.Net/Clients/SpotApi/BybitBaseSocketClientSpotStreams.cs
@@ -1,0 +1,36 @@
+﻿using Bybit.Net.Objects;
+using CryptoExchange.Net;
+using CryptoExchange.Net.Authentication;
+using CryptoExchange.Net.Objects;
+using CryptoExchange.Net.Sockets;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using CryptoExchange.Net.Logging;
+using Bybit.Net.Objects.Models.Socket.Spot;
+using Bybit.Net.Enums;
+using Bybit.Net.Objects.Models.Spot;
+using Bybit.Net.Interfaces.Clients.SpotApi;
+
+namespace Bybit.Net.Clients.SpotApi
+{
+    /// <inheritdoc cref="IBybitSocketClientSpotStreamsV2" />
+    public abstract class BybitBaseSocketClientSpotStreams : SocketApiClient
+    {
+        protected readonly Log _log;
+        protected readonly BybitSocketClient _baseClient;
+        protected readonly BybitSocketClientOptions _options;
+
+        internal BybitBaseSocketClientSpotStreams(Log log, BybitSocketClient baseClient, BybitSocketClientOptions options, BybitSocketApiClientOptions apiOptions)
+            : base(options, apiOptions)
+        {
+            _log = log;
+            _options = options;
+            _baseClient = baseClient;
+        }
+
+        /// <inheritdoc />
+        protected override AuthenticationProvider CreateAuthenticationProvider(ApiCredentials credentials)
+            => new BybitAuthenticationProvider(credentials);
+    }
+}

--- a/ByBit.Net/Clients/SpotApi/BybitSocketClientSpotStreamsV1.cs
+++ b/ByBit.Net/Clients/SpotApi/BybitSocketClientSpotStreamsV1.cs
@@ -1,0 +1,274 @@
+﻿using Bybit.Net.Objects.Internal.Socket;
+using Bybit.Net.Objects;
+using CryptoExchange.Net;
+using CryptoExchange.Net.Authentication;
+using CryptoExchange.Net.Objects;
+using CryptoExchange.Net.Sockets;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using CryptoExchange.Net.Logging;
+using Bybit.Net.Objects.Models.Socket.Spot;
+using Bybit.Net.Enums;
+using Bybit.Net.Converters;
+using Bybit.Net.Objects.Models.Spot;
+using Bybit.Net.Interfaces.Clients.SpotApi;
+
+namespace Bybit.Net.Clients.SpotApi
+{
+    /// <inheritdoc cref="IBybitSocketClientSpotStreamsV2" />
+    public class BybitSocketClientSpotStreamsV1 : BybitBaseSocketClientSpotStreams, IBybitSocketClientSpotStreamsV1
+    {
+        internal BybitSocketClientSpotStreamsV1(Log log, BybitSocketClient baseClient, BybitSocketClientOptions options)
+            : base(log, baseClient, options, options.SpotStreamsV1Options)
+        {
+        }
+
+        /// <inheritdoc />
+        public async Task<CallResult<UpdateSubscription>> SubscribeToTradeUpdatesAsync(string symbol, Action<DataEvent<BybitSpotTradeUpdate>> handler, CancellationToken ct = default)
+        {
+            var internalHandler = new Action<DataEvent<JToken>>(data =>
+            {
+                var internalDataArray = data.Data["data"];
+                if (internalDataArray == null)
+                    return;
+
+                var internalData = internalDataArray.First;
+                if (internalData == null)
+                {
+                    return;
+                }
+
+                var desResult = _baseClient.DeserializeInternal<BybitSpotTradeUpdate>(internalData);
+                if (!desResult)
+                {
+                    _log.Write(LogLevel.Warning, $"Failed to deserialize {nameof(BybitSpotTradeUpdate)} object: " + desResult.Error);
+                    return;
+                }
+
+                handler(data.As(desResult.Data, data.Data["symbol"]?.ToString()));
+            });
+            return await _baseClient.SubscribeInternalAsync(this,
+                new BybitSpotRequestMessageV1()
+                {
+                    Operation = "trade",
+                    Event = "sub",
+                    Symbol = symbol
+                },
+                null, false, internalHandler, ct).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc />
+        public async Task<CallResult<UpdateSubscription>> SubscribeToOrderBookUpdatesAsync(string symbol, Action<DataEvent<BybitSpotOrderBookUpdate>> handler, CancellationToken ct = default)
+        {
+            var internalHandler = new Action<DataEvent<JToken>>(data =>
+            {
+                var internalDataArray = data.Data["data"];
+                if (internalDataArray == null)
+                    return;
+
+                var internalData = internalDataArray.First;
+                if (internalData == null)
+                {
+                    return;
+                }
+
+                var desResult = _baseClient.DeserializeInternal<BybitSpotOrderBookUpdate>(internalData);
+                if (!desResult)
+                {
+                    _log.Write(LogLevel.Warning, $"Failed to deserialize {nameof(BybitSpotOrderBookUpdate)} object: " + desResult.Error);
+                    return;
+                }
+
+                handler(data.As(desResult.Data, data.Data["symbol"]?.ToString()));
+            });
+            return await _baseClient.SubscribeInternalAsync(this,
+                new BybitSpotRequestMessageV1()
+                {
+                    Operation = "depth",
+                    Event = "sub",
+                    Symbol = symbol
+                },
+                null, false, internalHandler, ct).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc />
+        public async Task<CallResult<UpdateSubscription>> SubscribeToKlineUpdatesAsync(string symbol, KlineInterval interval, Action<DataEvent<BybitSpotKlineUpdate>> handler, CancellationToken ct = default)
+        {
+            var internalHandler = new Action<DataEvent<JToken>>(data =>
+            {
+                var internalDataArray = data.Data["data"];
+                if (internalDataArray == null)
+                    return;
+
+                var internalData = internalDataArray.First;
+                if (internalData == null)
+                {
+                    return;
+                }
+
+                var desResult = _baseClient.DeserializeInternal<BybitSpotKlineUpdate>(internalData);
+                if (!desResult)
+                {
+                    _log.Write(LogLevel.Warning, $"Failed to deserialize {nameof(BybitSpotKlineUpdate)} object: " + desResult.Error);
+                    return;
+                }
+
+                handler(data.As(desResult.Data, data.Data["symbol"]?.ToString()));
+            });
+            return await _baseClient.SubscribeInternalAsync(this,
+                new BybitSpotRequestMessageV1()
+                {
+                    Operation = $"kline_{KlineIntervalSpotConverter.ToString(interval)}",
+                    Event = "sub",
+                    Symbol = symbol
+                },
+                null, false, internalHandler, ct).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc />
+        public async Task<CallResult<UpdateSubscription>> SubscribeToTickerUpdatesAsync(string symbol, Action<DataEvent<BybitSpotTickerUpdate>> handler, CancellationToken ct = default)
+        {
+            var internalHandler = new Action<DataEvent<JToken>>(data =>
+            {
+                var internalDataArray = data.Data["data"];
+                if (internalDataArray == null)
+                    return;
+
+                var internalData = internalDataArray.First;
+
+                if (internalData == null)
+                {
+                    return;
+                }
+
+                var desResult = _baseClient.DeserializeInternal<BybitSpotTickerUpdate>(internalData);
+                if (!desResult)
+                {
+                    _log.Write(LogLevel.Warning, $"Failed to deserialize {nameof(BybitSpotTickerUpdate)} object: " + desResult.Error);
+                    return;
+                }
+
+                handler(data.As(desResult.Data, data.Data["symbol"]?.ToString()));
+            });
+            return await _baseClient.SubscribeInternalAsync(this,
+                new BybitSpotRequestMessageV1()
+                {
+                    Operation = "realtimes",
+                    Event = "sub",
+                    Symbol = symbol
+                },
+                null, false, internalHandler, ct).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc />
+        public async Task<CallResult<UpdateSubscription>> SubscribeToOrderBookMergedUpdatesAsync(string symbol, int dumpScale, Action<DataEvent<BybitSpotOrderBookUpdate>> handler, CancellationToken ct = default)
+        {
+            var internalHandler = new Action<DataEvent<JToken>>(data =>
+            {
+                var internalDataArray = data.Data["data"];
+                if (internalDataArray == null)
+                    return;
+
+                var internalData = internalDataArray.First;
+                if (internalData == null)
+                {
+                    return;
+                }
+
+                var desResult = _baseClient.DeserializeInternal<BybitSpotOrderBookUpdate>(internalData);
+                if (!desResult)
+                {
+                    _log.Write(LogLevel.Warning, $"Failed to deserialize {nameof(BybitSpotOrderBookUpdate)} object: " + desResult.Error);
+                    return;
+                }
+
+                handler(data.As(desResult.Data, data.Data["symbol"]?.ToString()));
+            });
+            return await _baseClient.SubscribeInternalAsync(this,
+                new BybitSpotRequestMessageV1()
+                {
+                    Operation = "mergedDepth",
+                    Event = "sub",
+                    Symbol = symbol,
+                    Parameters = new Dictionary<string, object>
+                    {
+                        { "dumpScale", dumpScale }
+                    }
+                },
+                null, false, internalHandler, ct).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc />
+        public async Task<CallResult<UpdateSubscription>> SubscribeToOrderBookDiffUpdatesAsync(string symbol, Action<DataEvent<BybitSpotOrderBookUpdate>> handler, CancellationToken ct = default)
+        {
+            var internalHandler = new Action<DataEvent<JToken>>(data =>
+            {
+                var internalDataArray = data.Data["data"];
+                if (internalDataArray == null)
+                    return;
+
+                var internalData = internalDataArray.First;
+                if (internalData == null)
+                {
+                    return;
+                }
+
+                var desResult = _baseClient.DeserializeInternal<BybitSpotOrderBookUpdate>(internalData);
+                if (!desResult)
+                {
+                    _log.Write(LogLevel.Warning, $"Failed to deserialize {nameof(BybitSpotOrderBookUpdate)} object: " + desResult.Error);
+                    return;
+                }
+
+                handler(data.As(desResult.Data, data.Data["symbol"]?.ToString()));
+            });
+            return await _baseClient.SubscribeInternalAsync(this,
+                new BybitSpotRequestMessageV1()
+                {
+                    Operation = "diffDepth",
+                    Event = "sub",
+                    Symbol = symbol
+                },
+                null, false, internalHandler, ct).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc />
+        public async Task<CallResult<UpdateSubscription>> SubscribeToLeverageTokenUpdatesAsync(string symbol, Action<DataEvent<BybitSpotLeverageUpdate>> handler, CancellationToken ct = default)
+        {
+            var internalHandler = new Action<DataEvent<JToken>>(data =>
+            {
+                var internalDataArray = data.Data["data"];
+                if (internalDataArray == null)
+                    return;
+
+                var internalData = internalDataArray.First;
+                if (internalData == null)
+                {
+                    return;
+                }
+
+                var desResult = _baseClient.DeserializeInternal<BybitSpotLeverageUpdate>(internalData);
+                if (!desResult)
+                {
+                    _log.Write(LogLevel.Warning, $"Failed to deserialize {nameof(BybitSpotLeverageUpdate)} object: " + desResult.Error);
+                    return;
+                }
+
+                handler(data.As(desResult.Data, data.Data["symbol"]?.ToString()));
+            });
+            return await _baseClient.SubscribeInternalAsync(this,
+                new BybitSpotRequestMessageV1()
+                {
+                    Operation = "lt",
+                    Event = "sub",
+                    Symbol = "$\"{symbol}NAV\""
+                },
+                null, false, internalHandler, ct).ConfigureAwait(false);
+        }
+    }
+}

--- a/ByBit.Net/Clients/SpotApi/BybitSocketClientSpotStreamsV2.cs
+++ b/ByBit.Net/Clients/SpotApi/BybitSocketClientSpotStreamsV2.cs
@@ -20,24 +20,13 @@ using Bybit.Net.Interfaces.Clients.SpotApi;
 
 namespace Bybit.Net.Clients.SpotApi
 {
-    /// <inheritdoc cref="IBybitSocketClientSpotStreams" />
-    public class BybitSocketClientSpotStreams : SocketApiClient, IBybitSocketClientSpotStreams
+    /// <inheritdoc cref="IBybitSocketClientSpotStreamsV2" />
+    public class BybitSocketClientSpotStreamsV2 : BybitBaseSocketClientSpotStreams, IBybitSocketClientSpotStreamsV2
     {
-        private readonly Log _log;
-        private readonly BybitSocketClient _baseClient;
-        private readonly BybitSocketClientOptions _options;
-
-        internal BybitSocketClientSpotStreams(Log log, BybitSocketClient baseClient, BybitSocketClientOptions options)
-            : base(options, options.SpotStreamsOptions)
+        internal BybitSocketClientSpotStreamsV2(Log log, BybitSocketClient baseClient, BybitSocketClientOptions options)
+            : base(log, baseClient,options, options.SpotStreamsV2Options)
         {
-            _log = log;
-            _options = options;
-            _baseClient = baseClient;
         }
-
-        /// <inheritdoc />
-        protected override AuthenticationProvider CreateAuthenticationProvider(ApiCredentials credentials)
-            => new BybitAuthenticationProvider(credentials);
 
         /// <inheritdoc />
         public async Task<CallResult<UpdateSubscription>> SubscribeToTradeUpdatesAsync(string symbol, Action<DataEvent<BybitSpotTradeUpdate>> handler, CancellationToken ct = default)
@@ -58,7 +47,7 @@ namespace Bybit.Net.Clients.SpotApi
                 handler(data.As(desResult.Data, data.Data["params"]?["symbol"]?.ToString()));
             });
             return await _baseClient.SubscribeInternalAsync(this,
-                new BybitSpotRequestMessage()
+                new BybitSpotRequestMessageV2()
                 {
                     Operation = "trade",
                     Event = "sub",
@@ -89,7 +78,7 @@ namespace Bybit.Net.Clients.SpotApi
                 handler(data.As(desResult.Data, data.Data["params"]?["symbol"]?.ToString()));
             });
             return await _baseClient.SubscribeInternalAsync(this,
-                new BybitSpotRequestMessage()
+                new BybitSpotRequestMessageV2()
                 {
                     Operation = "depth",
                     Event = "sub",
@@ -120,7 +109,7 @@ namespace Bybit.Net.Clients.SpotApi
                 handler(data.As(desResult.Data, data.Data["params"]?["symbol"]?.ToString()));
             });
             return await _baseClient.SubscribeInternalAsync(this,
-                new BybitSpotRequestMessage()
+                new BybitSpotRequestMessageV2()
                 {
                     Operation = "kline",
                     Event = "sub",
@@ -152,7 +141,7 @@ namespace Bybit.Net.Clients.SpotApi
                 handler(data.As(desResult.Data, data.Data["params"]?["symbol"]?.ToString()));
             });
             return await _baseClient.SubscribeInternalAsync(this,
-                new BybitSpotRequestMessage()
+                new BybitSpotRequestMessageV2()
                 {
                     Operation = "bookTicker",
                     Event = "sub",
@@ -183,7 +172,7 @@ namespace Bybit.Net.Clients.SpotApi
                 handler(data.As(desResult.Data, data.Data["params"]?["symbol"]?.ToString()));
             });
             return await _baseClient.SubscribeInternalAsync(this,
-                new BybitSpotRequestMessage()
+                new BybitSpotRequestMessageV2()
                 {
                     Operation = "realtimes",
                     Event = "sub",
@@ -250,7 +239,7 @@ namespace Bybit.Net.Clients.SpotApi
             });
             return await _baseClient.SubscribeInternalAsync(
                 this,
-                _options.SpotStreamsOptions.BaseAddressAuthenticated,
+                _options.SpotStreamsV2Options.BaseAddressAuthenticated,
                 null,
                 "AccountInfo", true, internalHandler, ct).ConfigureAwait(false);
         }

--- a/ByBit.Net/Converters/KlineIntervalSpotConverter.cs
+++ b/ByBit.Net/Converters/KlineIntervalSpotConverter.cs
@@ -1,6 +1,7 @@
 ﻿using Bybit.Net.Enums;
 using CryptoExchange.Net.Converters;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Bybit.Net.Converters
 {
@@ -9,7 +10,7 @@ namespace Bybit.Net.Converters
         public KlineIntervalSpotConverter() : this(true) { }
         public KlineIntervalSpotConverter(bool quotes) : base(quotes) { }
 
-        protected override List<KeyValuePair<KlineInterval, string>> Mapping => new List<KeyValuePair<KlineInterval, string>>
+        private static List<KeyValuePair<KlineInterval, string>> _mapping => new List<KeyValuePair<KlineInterval, string>>
         {
             new KeyValuePair<KlineInterval, string>(KlineInterval.OneMinute, "1m"),
             new KeyValuePair<KlineInterval, string>(KlineInterval.ThreeMinutes, "3m"),
@@ -25,5 +26,12 @@ namespace Bybit.Net.Converters
             new KeyValuePair<KlineInterval, string>(KlineInterval.OneWeek, "1w"),
             new KeyValuePair<KlineInterval, string>(KlineInterval.OneMonth, "1M"),
         };
+
+        public static string ToString(KlineInterval interval)
+        {
+            return _mapping.First(x => x.Key == interval).Value;
+        }
+
+        protected override List<KeyValuePair<KlineInterval, string>> Mapping => new List<KeyValuePair<KlineInterval, string>>(_mapping);
     }
 }

--- a/ByBit.Net/Interfaces/Clients/IBybitSocketClient.cs
+++ b/ByBit.Net/Interfaces/Clients/IBybitSocketClient.cs
@@ -15,9 +15,13 @@ namespace Bybit.Net.Interfaces.Clients
         /// </summary>
         public IBybitSocketClientUsdPerpetualStreams UsdPerpetualStreams { get; }
         /// <summary>
-        /// Spot streams
+        /// Spot streams v1
         /// </summary>
-        public IBybitSocketClientSpotStreams SpotStreams { get; }
+        public IBybitSocketClientSpotStreamsV1 SpotStreamsV1 { get; }
+        /// <summary>
+        /// Spot streams v2
+        /// </summary>
+        public IBybitSocketClientSpotStreamsV2 SpotStreamsV2 { get; }
         /// <summary>
         /// Inverse perpetual streams
         /// </summary>

--- a/ByBit.Net/Interfaces/Clients/SpotApi/IBybitSocketClientSpotStreamsV1.cs
+++ b/ByBit.Net/Interfaces/Clients/SpotApi/IBybitSocketClientSpotStreamsV1.cs
@@ -1,6 +1,5 @@
 ﻿using Bybit.Net.Enums;
 using Bybit.Net.Objects.Models.Socket.Spot;
-using Bybit.Net.Objects.Models.Spot;
 using CryptoExchange.Net.Objects;
 using CryptoExchange.Net.Sockets;
 using System;
@@ -12,11 +11,11 @@ namespace Bybit.Net.Interfaces.Clients.SpotApi
     /// <summary>
     /// Bybit spot streams
     /// </summary>
-    public interface IBybitSocketClientSpotStreams
+    public interface IBybitSocketClientSpotStreamsV1
     {
         /// <summary>
         /// Subscribe to public trade updates
-        /// <para><a href="https://bybit-exchange.github.io/docs/spot/#t-websocketv2trade" /></para>
+        /// <para><a href="https://bybit-exchange.github.io/docs/spot/v1/#t-websockettrade" /></para>
         /// </summary>
         /// <param name="symbol">The symbol</param>
         /// <param name="handler">Data handler</param>
@@ -26,7 +25,7 @@ namespace Bybit.Net.Interfaces.Clients.SpotApi
 
         /// <summary>
         /// Subscribe to order book updates
-        /// <para><a href="https://bybit-exchange.github.io/docs/spot/#t-websocketv2depth" /></para>
+        /// <para><a href="https://bybit-exchange.github.io/docs/spot/v1/#t-websocketdepth" /></para>
         /// </summary>
         /// <param name="symbol">The symbol</param>
         /// <param name="handler">Data handler</param>
@@ -36,7 +35,7 @@ namespace Bybit.Net.Interfaces.Clients.SpotApi
 
         /// <summary>
         /// Subscribe to kline updates
-        /// <para><a href="https://bybit-exchange.github.io/docs/spot/#t-websocketv2kline" /></para>
+        /// <para><a href="https://bybit-exchange.github.io/docs/spot/v1/#t-websocketkline" /></para>
         /// </summary>
         /// <param name="symbol">The symbol</param>
         /// <param name="interval">Interval of the kline data</param>
@@ -46,18 +45,8 @@ namespace Bybit.Net.Interfaces.Clients.SpotApi
         Task<CallResult<UpdateSubscription>> SubscribeToKlineUpdatesAsync(string symbol, KlineInterval interval, Action<DataEvent<BybitSpotKlineUpdate>> handler, CancellationToken ct = default);
 
         /// <summary>
-        /// Subscribe to book price updates
-        /// <para><a href="https://bybit-exchange.github.io/docs/spot/#t-websocketv2bookticker" /></para>
-        /// </summary>
-        /// <param name="symbol">The symbol</param>
-        /// <param name="handler">Data handler</param>
-        /// <param name="ct">Cancellation token for closing this subscription</param>
-        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToBookPriceUpdatesAsync(string symbol, Action<DataEvent<BybitSpotBookPrice>> handler, CancellationToken ct = default);
-
-        /// <summary>
         /// Subscribe to ticker updates
-        /// <para><a href="https://bybit-exchange.github.io/docs/spot/#t-websocketv2realtimes" /></para>
+        /// <para><a href="https://bybit-exchange.github.io/docs/spot/v1/#t-websocketrealtimes" /></para>
         /// </summary>
         /// <param name="symbol">The symbol</param>
         /// <param name="handler">Data handler</param>
@@ -66,18 +55,34 @@ namespace Bybit.Net.Interfaces.Clients.SpotApi
         Task<CallResult<UpdateSubscription>> SubscribeToTickerUpdatesAsync(string symbol, Action<DataEvent<BybitSpotTickerUpdate>> handler, CancellationToken ct = default);
 
         /// <summary>
-        /// Subscribe to account data updates
-        /// <para><a href="https://bybit-exchange.github.io/docs/spot/#t-privatetopics" /></para>
+        /// Subscribe to aggregated order book updates
+        /// <para><a href="https://bybit-exchange.github.io/docs/spot/v1/#t-websocketmergeddepth" /></para>
         /// </summary>
-        /// <param name="accountUpdateHandler">Account(balance) update handler</param>
-        /// <param name="orderUpdateHandler">Order update handler</param>
-        /// <param name="tradeUpdateHandler">User trade update handler</param>
+        /// <param name="symbol">The symbol</param>
+        /// <param name="dumpScale">It refers to the number of decimal places, eg 1 for 50000.5 or 0 for 50000</param>
+        /// <param name="handler">Data handler</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>
         /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToAccountUpdatesAsync(
-            Action<DataEvent<BybitSpotAccountUpdate>> accountUpdateHandler,
-            Action<DataEvent<BybitSpotOrderUpdate>> orderUpdateHandler,
-            Action<DataEvent<BybitSpotUserTradeUpdate>> tradeUpdateHandler,
-            CancellationToken ct = default);
+        Task<CallResult<UpdateSubscription>> SubscribeToOrderBookMergedUpdatesAsync(string symbol, int dumpScale, Action<DataEvent<BybitSpotOrderBookUpdate>> handler, CancellationToken ct = default);
+
+        /// <summary>
+        /// Subscribe to diff of order book updates
+        /// <para><a href="https://bybit-exchange.github.io/docs/spot/v1/#t-websocketdiffdepth" /></para>
+        /// </summary>
+        /// <param name="symbol">The symbol</param>
+        /// <param name="handler">Data handler</param>
+        /// <param name="ct">Cancellation token for closing this subscription</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        Task<CallResult<UpdateSubscription>> SubscribeToOrderBookDiffUpdatesAsync(string symbol, Action<DataEvent<BybitSpotOrderBookUpdate>> handler, CancellationToken ct = default);
+
+        /// <summary>
+        /// Subscribe to leverage token net value updates
+        /// <para><a href="https://bybit-exchange.github.io/docs/spot/v1/#t-websocketltnetvalue" /></para>
+        /// </summary>
+        /// <param name="symbol">The symbol</param>
+        /// <param name="handler">Data handler</param>
+        /// <param name="ct">Cancellation token for closing this subscription</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        Task<CallResult<UpdateSubscription>> SubscribeToLeverageTokenUpdatesAsync(string symbol, Action<DataEvent<BybitSpotLeverageUpdate>> handler, CancellationToken ct = default);
     }
 }

--- a/ByBit.Net/Interfaces/Clients/SpotApi/IBybitSocketClientSpotStreamsV2.cs
+++ b/ByBit.Net/Interfaces/Clients/SpotApi/IBybitSocketClientSpotStreamsV2.cs
@@ -1,0 +1,83 @@
+﻿using Bybit.Net.Enums;
+using Bybit.Net.Objects.Models.Socket.Spot;
+using Bybit.Net.Objects.Models.Spot;
+using CryptoExchange.Net.Objects;
+using CryptoExchange.Net.Sockets;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Bybit.Net.Interfaces.Clients.SpotApi
+{
+    /// <summary>
+    /// Bybit spot streams
+    /// </summary>
+    public interface IBybitSocketClientSpotStreamsV2
+    {
+        /// <summary>
+        /// Subscribe to public trade updates
+        /// <para><a href="https://bybit-exchange.github.io/docs/spot/#t-websocketv2trade" /></para>
+        /// </summary>
+        /// <param name="symbol">The symbol</param>
+        /// <param name="handler">Data handler</param>
+        /// <param name="ct">Cancellation token for closing this subscription</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        Task<CallResult<UpdateSubscription>> SubscribeToTradeUpdatesAsync(string symbol, Action<DataEvent<BybitSpotTradeUpdate>> handler, CancellationToken ct = default);
+
+        /// <summary>
+        /// Subscribe to order book updates
+        /// <para><a href="https://bybit-exchange.github.io/docs/spot/#t-websocketv2depth" /></para>
+        /// </summary>
+        /// <param name="symbol">The symbol</param>
+        /// <param name="handler">Data handler</param>
+        /// <param name="ct">Cancellation token for closing this subscription</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        Task<CallResult<UpdateSubscription>> SubscribeToOrderBookUpdatesAsync(string symbol, Action<DataEvent<BybitSpotOrderBookUpdate>> handler, CancellationToken ct = default);
+
+        /// <summary>
+        /// Subscribe to kline updates
+        /// <para><a href="https://bybit-exchange.github.io/docs/spot/#t-websocketv2kline" /></para>
+        /// </summary>
+        /// <param name="symbol">The symbol</param>
+        /// <param name="interval">Interval of the kline data</param>
+        /// <param name="handler">Data handler</param>
+        /// <param name="ct">Cancellation token for closing this subscription</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        Task<CallResult<UpdateSubscription>> SubscribeToKlineUpdatesAsync(string symbol, KlineInterval interval, Action<DataEvent<BybitSpotKlineUpdate>> handler, CancellationToken ct = default);
+
+        /// <summary>
+        /// Subscribe to book price updates
+        /// <para><a href="https://bybit-exchange.github.io/docs/spot/#t-websocketv2bookticker" /></para>
+        /// </summary>
+        /// <param name="symbol">The symbol</param>
+        /// <param name="handler">Data handler</param>
+        /// <param name="ct">Cancellation token for closing this subscription</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        Task<CallResult<UpdateSubscription>> SubscribeToBookPriceUpdatesAsync(string symbol, Action<DataEvent<BybitSpotBookPrice>> handler, CancellationToken ct = default);
+
+        /// <summary>
+        /// Subscribe to ticker updates
+        /// <para><a href="https://bybit-exchange.github.io/docs/spot/#t-websocketv2realtimes" /></para>
+        /// </summary>
+        /// <param name="symbol">The symbol</param>
+        /// <param name="handler">Data handler</param>
+        /// <param name="ct">Cancellation token for closing this subscription</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        Task<CallResult<UpdateSubscription>> SubscribeToTickerUpdatesAsync(string symbol, Action<DataEvent<BybitSpotTickerUpdate>> handler, CancellationToken ct = default);
+
+        /// <summary>
+        /// Subscribe to account data updates
+        /// <para><a href="https://bybit-exchange.github.io/docs/spot/#t-privatetopics" /></para>
+        /// </summary>
+        /// <param name="accountUpdateHandler">Account(balance) update handler</param>
+        /// <param name="orderUpdateHandler">Order update handler</param>
+        /// <param name="tradeUpdateHandler">User trade update handler</param>
+        /// <param name="ct">Cancellation token for closing this subscription</param>
+        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
+        Task<CallResult<UpdateSubscription>> SubscribeToAccountUpdatesAsync(
+            Action<DataEvent<BybitSpotAccountUpdate>> accountUpdateHandler,
+            Action<DataEvent<BybitSpotOrderUpdate>> orderUpdateHandler,
+            Action<DataEvent<BybitSpotUserTradeUpdate>> tradeUpdateHandler,
+            CancellationToken ct = default);
+    }
+}

--- a/ByBit.Net/Objects/BybitApiAddresses.cs
+++ b/ByBit.Net/Objects/BybitApiAddresses.cs
@@ -15,9 +15,13 @@
         /// </summary>
         public string CopyTradingRestClientAddress { get; set; } = "";
         /// <summary>
-        /// The address used by the BybitSocketClient for the public Spot socket API
+        /// The address used by the BybitSocketClient for the public Spot socket API v1
         /// </summary>
-        public string SpotPublicSocketClientAddress { get; set; } = "";
+        public string SpotPublicSocketV1ClientAddress { get; set; } = "";
+        /// <summary>
+        /// The address used by the BybitSocketClient for the public Spot socket API v2
+        /// </summary>
+        public string SpotPublicSocketV2ClientAddress { get; set; } = "";
         /// <summary>
         /// The address used by the BybitSocketClient for the private Spot socket API
         /// </summary>
@@ -64,7 +68,8 @@
         public static BybitApiAddresses Default = new BybitApiAddresses
         {
             SpotRestClientAddress = "https://api.bybit.com",
-            SpotPublicSocketClientAddress = "wss://stream.bybit.com/spot/quote/ws/v2",
+            SpotPublicSocketV1ClientAddress = "wss://stream.bybit.com/spot/quote/ws/v1",
+            SpotPublicSocketV2ClientAddress = "wss://stream.bybit.com/spot/quote/ws/v2",
             SpotPrivateSocketClientAddress = "wss://stream.bybit.com/spot/ws",
             UsdPerpetualRestClientAddress = "https://api.bybit.com",
             UsdPerpetualPublicSocketClientAddress = "wss://stream.bybit.com/realtime_public",
@@ -83,7 +88,8 @@
         public static BybitApiAddresses TestNet = new BybitApiAddresses
         {
             SpotRestClientAddress = "https://api-testnet.bybit.com",
-            SpotPublicSocketClientAddress = "wss://stream-testnet.bybit.com/spot/quote/ws/v2",
+            SpotPublicSocketV1ClientAddress = "wss://stream-testnet.bybit.com/spot/quote/ws/v1",
+            SpotPublicSocketV2ClientAddress = "wss://stream-testnet.bybit.com/spot/quote/ws/v2",
             SpotPrivateSocketClientAddress = "wss://stream-testnet.bybit.com/spot/ws",
             UsdPerpetualRestClientAddress = "https://api-testnet.bybit.com",
             UsdPerpetualPublicSocketClientAddress = "wss://stream-testnet.bybit.com/realtime_public",

--- a/ByBit.Net/Objects/BybitClientOptions.cs
+++ b/ByBit.Net/Objects/BybitClientOptions.cs
@@ -145,14 +145,24 @@ namespace Bybit.Net.Objects
             set => _usdPerpetualStreamsOptions = new BybitSocketApiClientOptions(_usdPerpetualStreamsOptions, value);
         }
 
-        private BybitSocketApiClientOptions _spotStreamsOptions = new BybitSocketApiClientOptions(BybitApiAddresses.Default.SpotPublicSocketClientAddress, BybitApiAddresses.Default.SpotPrivateSocketClientAddress);
+        private BybitSocketApiClientOptions _spotStreamsV1Options = new BybitSocketApiClientOptions(BybitApiAddresses.Default.SpotPublicSocketV1ClientAddress, BybitApiAddresses.Default.SpotPrivateSocketClientAddress);
         /// <summary>
-        /// Spot streams options
+        /// Spot streams options version 1
         /// </summary>
-        public BybitSocketApiClientOptions SpotStreamsOptions
+        public BybitSocketApiClientOptions SpotStreamsV1Options
         {
-            get => _spotStreamsOptions;
-            set => _spotStreamsOptions = new BybitSocketApiClientOptions(_spotStreamsOptions, value);
+            get => _spotStreamsV1Options;
+            set => _spotStreamsV1Options = new BybitSocketApiClientOptions(_spotStreamsV1Options, value);
+        }
+
+        private BybitSocketApiClientOptions _spotStreamsV2Options = new BybitSocketApiClientOptions(BybitApiAddresses.Default.SpotPublicSocketV2ClientAddress, BybitApiAddresses.Default.SpotPrivateSocketClientAddress);
+        /// <summary>
+        /// Spot streams options version 2
+        /// </summary>
+        public BybitSocketApiClientOptions SpotStreamsV2Options
+        {
+            get => _spotStreamsV2Options;
+            set => _spotStreamsV2Options = new BybitSocketApiClientOptions(_spotStreamsV2Options, value);
         }
 
         private BybitSocketApiClientOptions _copyTradingStreamsOptions = new BybitSocketApiClientOptions(BybitApiAddresses.Default.CopyTradingSocketClientAddress, BybitApiAddresses.Default.CopyTradingSocketClientAddress);
@@ -190,7 +200,8 @@ namespace Bybit.Net.Objects
 
             InverseFuturesStreamsOptions = new BybitSocketApiClientOptions(baseOn.InverseFuturesStreamsOptions, null);
             InversePerpetualStreamsOptions = new BybitSocketApiClientOptions(baseOn.InversePerpetualStreamsOptions, null);
-            SpotStreamsOptions = new BybitSocketApiClientOptions(baseOn.SpotStreamsOptions, null);
+            SpotStreamsV1Options = new BybitSocketApiClientOptions(baseOn.SpotStreamsV1Options, null);
+            SpotStreamsV2Options = new BybitSocketApiClientOptions(baseOn.SpotStreamsV2Options, null);
             UsdPerpetualStreamsOptions = new BybitSocketApiClientOptions(baseOn.UsdPerpetualStreamsOptions, null);
         }
     }
@@ -229,7 +240,7 @@ namespace Bybit.Net.Objects
         /// </summary>
         /// <param name="baseAddress"></param>
         /// <param name="baseAddressAuthenticated"></param>
-        internal BybitSocketApiClientOptions(string baseAddress, string baseAddressAuthenticated): base(baseAddress)
+        internal BybitSocketApiClientOptions(string baseAddress, string baseAddressAuthenticated) : base(baseAddress)
         {
             BaseAddressAuthenticated = baseAddressAuthenticated;
         }

--- a/ByBit.Net/Objects/Internal/Socket/BybitRequestMessage.cs
+++ b/ByBit.Net/Objects/Internal/Socket/BybitRequestMessage.cs
@@ -12,7 +12,13 @@ namespace Bybit.Net.Objects.Internal.Socket
         public object[] Parameters { get; set; } = Array.Empty<object>();
     }
 
-    internal class BybitSpotRequestMessage
+    internal class BybitSpotRequestMessageV1 : BybitSpotRequestMessageV2
+    {
+        [JsonProperty("symbol")]
+        public string Symbol { get; set; } = string.Empty;
+    }
+
+    internal class BybitSpotRequestMessageV2
     {
         [JsonProperty("topic")]
         public string Operation { get; set; } = string.Empty;

--- a/ByBit.Net/Objects/Models/Socket/Spot/BybitSpotLeverageUpdate.cs
+++ b/ByBit.Net/Objects/Models/Socket/Spot/BybitSpotLeverageUpdate.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using CryptoExchange.Net.Converters;
+using Newtonsoft.Json;
+
+namespace Bybit.Net.Objects.Models.Socket.Spot
+{
+    /// <summary>
+    /// Leverage Token Net value update
+    /// </summary>
+    public class BybitSpotLeverageUpdate
+    {
+        /// <summary>
+        /// Timestamp
+        /// </summary>
+        [JsonConverter(typeof(DateTimeConverter))]
+        [JsonProperty("t")]
+        public DateTime Timestamp { get; set; }
+        /// <summary>
+        /// Symbol
+        /// </summary>
+        /// <remarks> Please make sure to add "NAV" as a suffix to the name of the pair you're querying </remarks>
+        [JsonProperty("s")]
+        public string Symbol { get; set; }
+        /// <summary>
+        /// Net asset value
+        /// </summary>
+        [JsonProperty("nav")]
+        public decimal NetAssetValue { get; set; }
+        /// <summary>
+        /// Basket value
+        /// </summary>
+        [JsonProperty("b")]
+        public decimal BasketValue { get; set; }
+        /// <summary>
+        /// Real Leverage calculated by last traded price.
+        /// </summary>
+        [JsonProperty("l")]
+        public decimal RealLeverage { get; set; }
+        /// <summary>
+        /// Basket loan
+        /// </summary>
+        [JsonProperty("loan")]
+        public decimal BasketLoan { get; set; }
+        /// <summary>
+        /// Circulating supply in the secondary market
+        /// </summary>
+        [JsonProperty("ti")]
+        public decimal CirculatingSupply { get; set; }
+        /// <summary>
+        /// Total position value = basket value * total circulation
+        /// </summary>
+        [JsonProperty("n")]
+        public decimal TotalPositionValue { get; set; }
+    }
+}

--- a/ByBit.Net/SymbolOrderBooks/BybitSpotSymbolOrderBook.cs
+++ b/ByBit.Net/SymbolOrderBooks/BybitSpotSymbolOrderBook.cs
@@ -43,7 +43,7 @@ namespace Bybit.Net.SymbolOrderBooks
         /// <inheritdoc />
         protected override async Task<CallResult<UpdateSubscription>> DoStartAsync(CancellationToken ct)
         {
-            var result = await socketClient.SpotStreams.SubscribeToOrderBookUpdatesAsync(Symbol, ProcessUpdate).ConfigureAwait(false);
+            var result = await socketClient.SpotStreamsV2.SubscribeToOrderBookUpdatesAsync(Symbol, ProcessUpdate).ConfigureAwait(false);
             if (!result)
                 return result;
 


### PR DESCRIPTION
There was a need to get access to the functions of spot version 1 (diffDepth: https://bybit-exchange.github.io/docs/spot/v1/#t-websocketdiffdepth).
Therefore desided that it would be nice to have access for both versions of a spot API.