### PR TITLE
Issue with getting trigger price for a STOP LIMIT spot orders

### DIFF
--- a/ByBit.Net/Objects/Models/Spot/v3/BybitSpotOrderV3.cs
+++ b/ByBit.Net/Objects/Models/Spot/v3/BybitSpotOrderV3.cs
@@ -44,7 +44,7 @@ namespace Bybit.Net.Objects.Models.Spot.v3
         /// Trigger price
         /// </summary>
         [JsonProperty("triggerPrice")]
-        private decimal TriggerPrice { get; set; }
+        public decimal TriggerPrice { get; set; }
 
         /// <summary>
         /// Order quantity

--- a/ByBit.Net/Objects/Models/Spot/v3/BybitSpotOrderV3.cs
+++ b/ByBit.Net/Objects/Models/Spot/v3/BybitSpotOrderV3.cs
@@ -41,6 +41,12 @@ namespace Bybit.Net.Objects.Models.Spot.v3
         }
 
         /// <summary>
+        /// Trigger price
+        /// </summary>
+        [JsonProperty("triggerPrice")]
+        private decimal TriggerPrice { get; set; }
+
+        /// <summary>
         /// Order quantity
         /// </summary>
         [JsonProperty("orderQty")]


### PR DESCRIPTION
There is an obsolette information in API documentation. They didn't describe trigger price in get open orders description;
https://bybit-exchange.github.io/docs/spot/v3/#t-openorders
However it's not correct and in responce we have this information. 

So, updated data information about spot orders, include trigger price here for processing stop limit orders.