### PR TITLE
Klines socket for USDT

### DIFF
--- a/ByBit.Net/Clients/UsdPerpetualApi/BybitSocketClientUsdPerpetualStreams.cs
+++ b/ByBit.Net/Clients/UsdPerpetualApi/BybitSocketClientUsdPerpetualStreams.cs
@@ -158,10 +158,6 @@ namespace Bybit.Net.Clients.UsdPerpetualApi
         }
 
         /// <inheritdoc />
-        public Task<CallResult<UpdateSubscription>> SubscribeToKlinesUpdatesAsync(KlineInterval interval, Action<DataEvent<IEnumerable<BybitKlineUpdate>>> handler, CancellationToken ct = default)
-            => SubscribeToKlineUpdatesAsync(new string[] { "*" }, interval, handler, ct);
-
-        /// <inheritdoc />
         public Task<CallResult<UpdateSubscription>> SubscribeToKlineUpdatesAsync(string symbol, KlineInterval interval, Action<DataEvent<IEnumerable<BybitKlineUpdate>>> handler, CancellationToken ct = default)
             => SubscribeToKlineUpdatesAsync(new string[] { symbol }, interval, handler, ct);
 

--- a/ByBit.Net/Interfaces/Clients/UsdPerpetualApi/IBybitSocketClientUsdPerpetualStreams.cs
+++ b/ByBit.Net/Interfaces/Clients/UsdPerpetualApi/IBybitSocketClientUsdPerpetualStreams.cs
@@ -124,16 +124,6 @@ namespace Bybit.Net.Interfaces.Clients.UsdPerpetualApi
         /// <para><a href="https://bybit-exchange.github.io/docs/futuresV2/linear/#t-websocketkline" /></para>
         /// </summary>
         /// <param name="interval">The interval of the klines</param>
-        /// <param name="handler">The event handler for the received data</param>
-        /// <param name="ct">Cancellation token for closing this subscription</param>
-        /// <returns>A stream subscription. This stream subscription can be used to be notified when the socket is disconnected/reconnected</returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToKlinesUpdatesAsync(KlineInterval interval, Action<DataEvent<IEnumerable<BybitKlineUpdate>>> handler, CancellationToken ct = default);
-
-        /// <summary>
-        /// Subscribe to kline (candlestick) updates
-        /// <para><a href="https://bybit-exchange.github.io/docs/futuresV2/linear/#t-websocketkline" /></para>
-        /// </summary>
-        /// <param name="interval">The interval of the klines</param>
         /// <param name="symbol">The symbol to receive updates for</param>
         /// <param name="handler">The event handler for the received data</param>
         /// <param name="ct">Cancellation token for closing this subscription</param>


### PR DESCRIPTION
https://github.com/JKorf/Bybit.Net/issues/84

I did some research, and it looks like the USDT perpetual (!) socket doesn't support subscribing Klines for all symbols with the "*" symbol. The API works fine for Inverse Perpetual (v2), but for USDT Perpetual, it constantly returns an error about subscribing.
The advice from tg API chat is to pass all symbols in an array.