### PR TITLE
Fixed a usage example

### DIFF
--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -29,11 +29,11 @@ var bybitClient = new BybitClient(new BybitClientOptions()
 {
 	ApiCredentials = new ApiCredentials("API-KEY", "API-SECRET"),
 	LogLevel = LogLevel.Trace,
-	RequestTimeout = TimeSpan.FromSeconds(60),
 	InverseFuturesApiOptions = new RestApiClientOptions
 	{
 		ApiCredentials = new ApiCredentials("FUTURES-API-KEY", "FUTURES-API-SECRET"),
-		AutoTimestamp = false
+		AutoTimestamp = false,
+		RequestTimeout = TimeSpan.FromSeconds(60)
 	}
 });
 ```


### PR DESCRIPTION
RequestTimeout is not a part of BybitClientOptions anymore. The current example fails to build and confusing for new starters. So, moved RequestTimeout to RestApiClientOptions.