### PR TITLE
Added missing attributes in BybitApiKeyInfo.

### DIFF
--- a/ByBit.Net/Objects/Models/ByBitApiKeyInfo.cs
+++ b/ByBit.Net/Objects/Models/ByBitApiKeyInfo.cs
@@ -56,5 +56,20 @@ namespace Bybit.Net.Objects.Models
         /// </summary>
         [JsonProperty("read_only")]
         public bool Readonly { get; set; }
+        /// <summary>
+        /// Vip Level
+        /// </summary>
+        [JsonProperty("vip_level")]
+        public string VipLevel { get; set; } = string.Empty;
+        /// <summary>
+        /// Market Maker Level
+        /// </summary>
+        [JsonProperty("mkt_maker_level")]
+        public int MarketMakerLevel { get; set; }
+        /// <summary>
+        /// Affiliate Id
+        /// </summary>
+        [JsonProperty("affiliate_id")]
+        public long AffiliateId { get; set; }
     }
 }


### PR DESCRIPTION
Dear JKorf,

I added three attributes to the ByBitApiKeyInfo class inside Models.
They refer to VipLevel, MarketMakerLevel and AffiliateId.

Thank you for providing the library.
Thank also to @kulikov-dev for the support during the creation of the pull.

Cheers,
Mirco