### PR TITLE
Add V3 GetApiKeyInformation

### DIFF
--- a/ByBit.Net/Clients/DerivativesApi/ContractApi/BybitClientContractApiTrading.cs
+++ b/ByBit.Net/Clients/DerivativesApi/ContractApi/BybitClientContractApiTrading.cs
@@ -50,8 +50,8 @@ namespace Bybit.Net.Clients.DerivativesApi.ContractApi
             parameters.AddOptionalParameter("tpTriggerBy", takeProfitTriggerType == null ? null : JsonConvert.SerializeObject(takeProfitTriggerType, new TriggerTypeConverter(false)));
             parameters.AddOptionalParameter("slTriggerBy", stopLossTriggerType == null ? null : JsonConvert.SerializeObject(stopLossTriggerType, new TriggerTypeConverter(false)));
 
-            parameters.AddOptionalParameter("reduceOnly", reduceOnly?.ToString(CultureInfo.InvariantCulture));
-            parameters.AddOptionalParameter("closeOnTrigger", closeOnTrigger?.ToString(CultureInfo.InvariantCulture));
+            parameters.AddOptionalParameter("reduceOnly", reduceOnly?.ToString(CultureInfo.InvariantCulture).ToLowerInvariant());
+            parameters.AddOptionalParameter("closeOnTrigger", closeOnTrigger?.ToString(CultureInfo.InvariantCulture).ToLowerInvariant());
 
             parameters.AddOptionalParameter("recv_window", receiveWindow?.ToString(CultureInfo.InvariantCulture) ?? _baseClient.ClientOptions.ReceiveWindow.TotalMilliseconds.ToString(CultureInfo.InvariantCulture));
 

--- a/ByBit.Net/Clients/GeneralApi/BybitClientGeneralApi.cs
+++ b/ByBit.Net/Clients/GeneralApi/BybitClientGeneralApi.cs
@@ -26,6 +26,8 @@ namespace Bybit.Net.Clients.GeneralApi
         public IBybitClientGeneralApiTransfer Transfer { get; }
         /// <inheritdoc />
         public IBybitClientGeneralApiWithdrawDeposit WithdrawDeposit { get; }
+        /// <inheritdoc />
+        public IBybitClientGeneralApiMasterSub MasterSub { get; }
 
         #region ctor
         internal BybitClientGeneralApi(Log log, BybitClient baseClient, BybitClientOptions options)
@@ -44,6 +46,7 @@ namespace Bybit.Net.Clients.GeneralApi
 
             Transfer = new BybitClientGeneralApiTransfer(this);
             WithdrawDeposit = new BybitClientGeneralApiWithdrawDeposit(this);
+            MasterSub = new BybitClientGeneralApiMasterSub(this);
 
             requestBodyFormat = RequestBodyFormat.Json;
             ParameterPositions[HttpMethod.Delete] = HttpMethodParameterPosition.InUri;

--- a/ByBit.Net/Clients/GeneralApi/BybitClientGeneralApiMasterSub.cs
+++ b/ByBit.Net/Clients/GeneralApi/BybitClientGeneralApiMasterSub.cs
@@ -1,0 +1,27 @@
+﻿using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Bybit.Net.Interfaces.Clients.GeneralApi;
+using Bybit.Net.Objects.Models;
+using CryptoExchange.Net.Objects;
+
+namespace Bybit.Net.Clients.GeneralApi
+{
+    /// <inheritdoc />
+    public class BybitClientGeneralApiMasterSub : IBybitClientGeneralApiMasterSub
+    {
+        private readonly BybitClientGeneralApi _baseClient;
+
+        internal BybitClientGeneralApiMasterSub(BybitClientGeneralApi baseClient)
+        {
+            _baseClient = baseClient;
+        }
+
+        /// <inheritdoc />
+        public async Task<WebCallResult<ByBitApiKeyInfoV3>> GetApiKeyInformation(CancellationToken ct = default)
+        {
+            var result = await _baseClient.SendRequestAsync<ByBitApiKeyInfoV3>(_baseClient.GetUrl("/user/v3/private/query-api"), HttpMethod.Get, ct, null, true).ConfigureAwait(false);
+            return result.As(result.Data);
+        }
+    }
+}

--- a/ByBit.Net/Interfaces/Clients/GeneralApi/IBybitClientGeneralApi.cs
+++ b/ByBit.Net/Interfaces/Clients/GeneralApi/IBybitClientGeneralApi.cs
@@ -13,8 +13,12 @@ namespace Bybit.Net.Interfaces.Clients.GeneralApi
         /// </summary>
         IBybitClientGeneralApiTransfer Transfer { get; }
         /// <summary>
-        /// Endpoint related to withrawing/depositing
+        /// Endpoint related to withdrawing/depositing
         /// </summary>
         IBybitClientGeneralApiWithdrawDeposit WithdrawDeposit { get; }
+        /// <summary>
+        /// Endpoint related to master/sub-accounts
+        /// </summary>
+        IBybitClientGeneralApiMasterSub MasterSub { get; }
     }
 }

--- a/ByBit.Net/Interfaces/Clients/GeneralApi/IBybitClientGeneralApiMasterSub.cs
+++ b/ByBit.Net/Interfaces/Clients/GeneralApi/IBybitClientGeneralApiMasterSub.cs
@@ -1,0 +1,21 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Bybit.Net.Objects.Models;
+using CryptoExchange.Net.Objects;
+
+namespace Bybit.Net.Interfaces.Clients.GeneralApi
+{
+    /// <summary>
+    /// Bybit user and API key endpoints
+    /// </summary>
+    public interface IBybitClientGeneralApiMasterSub
+    {
+        /// <summary>
+        /// Get the information of the api key. 
+        /// <para><a href="https://bybit-exchange.github.io/docs/account-asset/apikey-info" /></para>
+        /// </summary>
+        /// <param name="ct">Cancellation token</param>
+        /// <returns></returns>
+        Task<WebCallResult<ByBitApiKeyInfoV3>> GetApiKeyInformation(CancellationToken ct = default);
+    }
+}

--- a/ByBit.Net/Objects/Models/ByBitApiKeyInfoV3.cs
+++ b/ByBit.Net/Objects/Models/ByBitApiKeyInfoV3.cs
@@ -1,0 +1,127 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+
+namespace Bybit.Net.Objects.Models
+{
+    /// <summary>
+    /// Api key info
+    /// https://bybit-exchange.github.io/docs/account-asset/apikey-info
+    /// </summary>
+    public class ByBitApiKeyInfoV3
+    {
+        /// <summary>
+        /// Internal Bybit ID of ApiKey
+        /// </summary>
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        /// <summary>
+        /// Remark stored on the ApiKey
+        /// </summary>
+        [JsonProperty("note")]
+        public string Note { get; set; } = string.Empty;
+
+        /// <summary>
+        /// The api key
+        /// </summary>
+        [JsonProperty("apiKey")]
+        public string ApiKey { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Read/Write or ReadOnly
+        /// </summary>
+        [JsonProperty("readOnly")]
+        public bool ReadOnly { get; set; }
+
+        /// <summary>
+        /// Key permissions dictionary
+        /// </summary>
+        [JsonProperty("permissions")]
+        public Dictionary<string, string[]?> Permissions { get; set; } = new();
+
+        /// <summary>
+        /// IP whitelist
+        /// </summary>
+        [JsonProperty("ips")]
+        public IEnumerable<string> IpWhitelist { get; set; } = Array.Empty<string>();
+        
+        /// <summary>
+        /// Type of key
+        /// </summary>
+        [JsonProperty("type")]
+        public string Type { get; set; } = string.Empty;
+
+        /// <summary>
+        /// The remaining valid days of api key. Only for those api key with no IP bound or the password has been changed
+        /// </summary>
+        [JsonProperty("deadlineDay")]
+        public int DeadlineDay { get; set; }
+
+        /// <summary>
+        /// The expiry day of the api key. Only for those api key with no IP bound or the password has been changed
+        /// </summary>
+        [JsonProperty("expiredAt")]
+        public DateTime? ExpiredAt { get; set; }
+
+        /// <summary>
+        /// The create day of the api key
+        /// </summary>
+        [JsonProperty("createdAt")]
+        public DateTime CreatedAt { get; set; }
+
+        /// <summary>
+        /// Whether the account to which the api key belongs is a unified account. 0：regular account; 1：unified margin account
+        /// </summary>
+        [JsonProperty("unified")]
+        public int Unified { get; set; }
+
+        /// <summary>
+        /// Whether the account to which the account upgrade to unified trade account. 0：regular account; 1：unified trade account
+        /// </summary>
+        [JsonProperty("uta")]
+        public int UnifiedTradeAccount { get; set; }
+
+        /// <summary>
+        /// User id
+        /// </summary>
+        [JsonProperty("userID")]
+        public long UserId { get; set; }
+
+        /// <summary>
+        /// Inviter ID (the UID of the account which invited this account to the platform)
+        /// </summary>
+        [JsonProperty("inviterID")]
+        public long InviterId { get; set; }
+
+        /// <summary>
+        /// Vip Level
+        /// </summary>
+        [JsonProperty("vipLevel")]
+        public string VipLevel { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Market Maker Level
+        /// </summary>
+        [JsonProperty("mktMakerLevel")]
+        public int MarketMakerLevel { get; set; }
+
+        /// <summary>
+        /// Affiliate Id
+        /// </summary>
+        [JsonProperty("affiliateID")]
+        public long AffiliateId { get; set; }
+
+        /// <summary>
+        /// Rsa public key
+        /// </summary>
+        [JsonProperty("rsaPublicKey")]
+        public string RsaPublicKey { get; set; } = string.Empty;
+
+        /// <summary>
+        /// If this api key belongs to the master account or not
+        /// </summary>
+        [JsonProperty("isMaster")]
+        public bool IsMaster { get; set; }
+    }
+}

--- a/Bybit.UnitTests/JsonResponses/General/MasterSub/GetApiKeyInformation.txt
+++ b/Bybit.UnitTests/JsonResponses/General/MasterSub/GetApiKeyInformation.txt
@@ -1,0 +1,58 @@
+﻿{
+    "retCode": 0,
+    "retMsg": "",
+    "result": {
+        "id": "13770661",
+        "note": "XXXXXX",
+        "apiKey": "XXXXXX",
+        "readOnly": 0,
+        "secret": "",
+        "permissions": {
+            "ContractTrade": [
+            "Order",
+            "Position"
+                ],
+            "Spot": [
+            "SpotTrade"
+                ],
+            "Wallet": [
+            "AccountTransfer",
+            "SubMemberTransfer"
+                ],
+            "Options": [
+            "OptionsTrade"
+                ],
+            "Derivatives": [
+            "DerivativesTrade"
+                ],
+            "CopyTrading": [
+            "CopyTrading"
+                ],
+            "BlockTrade": [],
+            "Exchange": [
+            "ExchangeHistory"
+                ],
+            "NFT": [
+            "NFTQueryProductList"
+                ]
+        },
+        "ips": [
+        "*"
+            ],
+        "type": 1,
+        "deadlineDay": 83,
+        "expiredAt": "2023-05-15T03:21:05Z",
+        "createdAt": "2022-10-16T02:24:40Z",
+        "unified": 0,
+        "uta": 0,
+        "userID": 24600000,
+        "inviterID": 0,
+        "vipLevel": "No VIP",
+        "mktMakerLevel": "0",
+        "affiliateID": 0,
+        "rsaPublicKey": "",
+        "isMaster": false
+    },
+    "retExtInfo": {},
+    "time": 1676891757649
+}

--- a/Bybit.UnitTests/JsonTests.cs
+++ b/Bybit.UnitTests/JsonTests.cs
@@ -363,5 +363,20 @@ namespace Bybit.Net.UnitTests
                 useNestedJsonPropertyForAllCompare: new List<string> { "result" }
                 );
         }
+
+        [Test]
+        public async Task ValidateGeneralMasterSubCalls()
+        {
+            await _comparer.ProcessSubject("General/MasterSub", c => c.GeneralApi.MasterSub,
+                useNestedJsonPropertyForCompare: new Dictionary<string, string>
+                {
+                },
+                ignoreProperties: new Dictionary<string, List<string>>
+                {
+                },
+                useNestedJsonPropertyForAllCompare: new List<string> { "result" }
+
+            );
+        }
     }
 }


### PR DESCRIPTION
I've added a MasterSub Client to the General client with the ability retrieve the ApiKey Information using the V3 endpoint.

Because the existing Models.ByBitApiKeyInfo was for V1 and the structure has changed, I opted to add another type.

Happy for you to refactor this if required.

https://bybit-exchange.github.io/docs/account-asset/apikey-info