### PR TITLE
fix for #134 - V5Api.Trading.GetOrdersAsync() incorrect validation logic

### DIFF
--- a/ByBit.Net/Clients/V5/BybitClientApiTrading.cs
+++ b/ByBit.Net/Clients/V5/BybitClientApiTrading.cs
@@ -175,9 +175,9 @@ namespace Bybit.Net.Clients.V5
             string? cursor = null,
             CancellationToken ct = default)
         {
-            if (orderId == null != (clientOrderId == null))
+            if (orderId == null == (clientOrderId == null))
                 throw new ArgumentException("One of orderId or clientOrderId should be provided");
-
+      
             var parameters = new Dictionary<string, object>()
             {
                 { "category", EnumConverter.GetString(category) }

--- a/ByBit.Net/Objects/Models/V5/BybitLinearInverseTicker.cs
+++ b/ByBit.Net/Objects/Models/V5/BybitLinearInverseTicker.cs
@@ -75,7 +75,7 @@ namespace Bybit.Net.Objects.Models.V5
         /// <summary>
         /// Delivery fee rate
         /// </summary>
-        public decimal DeliveryFeeRate { get; set; }
+        public decimal? DeliveryFeeRate { get; set; }
         /// <summary>
         /// Delivery time
         /// </summary>
@@ -111,11 +111,11 @@ namespace Bybit.Net.Objects.Models.V5
         /// <summary>
         /// Basis rate
         /// </summary>
-        public decimal BasisRate { get; set; }
+        public decimal? BasisRate { get; set; }
         /// <summary>
         /// Basis
         /// </summary>
-        public decimal Basis { get; set; }
+        public decimal? Basis { get; set; }
         /// <summary>
         /// Predicted delivery price
         /// </summary>


### PR DESCRIPTION
fix for #134 - V5Api.Trading.GetOrdersAsync() incorrect validation logic