### PR TITLE
Fix liquidation stream response from IEnumerable to single object

### DIFF
--- a/ByBit.Net/Clients/V5/BybitSocketClientBaseApi.cs
+++ b/ByBit.Net/Clients/V5/BybitSocketClientBaseApi.cs
@@ -131,11 +131,11 @@ namespace Bybit.Net.Clients.V5
         }
 
         /// <inheritdoc />
-        public Task<CallResult<UpdateSubscription>> SubscribeToLiquidationUpdatesAsync(string symbol, Action<DataEvent<IEnumerable<BybitLiquidation>>> handler, CancellationToken ct = default)
+        public Task<CallResult<UpdateSubscription>> SubscribeToLiquidationUpdatesAsync(string symbol, Action<DataEvent<BybitLiquidation>> handler, CancellationToken ct = default)
             => SubscribeToLiquidationUpdatesAsync(new string[] { symbol }, handler, ct);
 
         /// <inheritdoc />
-        public async Task<CallResult<UpdateSubscription>> SubscribeToLiquidationUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<IEnumerable<BybitLiquidation>>> handler, CancellationToken ct = default)
+        public async Task<CallResult<UpdateSubscription>> SubscribeToLiquidationUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<BybitLiquidation>> handler, CancellationToken ct = default)
         {
             var internalHandler = new Action<DataEvent<JToken>>(data =>
             {
@@ -143,7 +143,7 @@ namespace Bybit.Net.Clients.V5
                 if (internalData == null)
                     return;
 
-                var desResult = Deserialize<IEnumerable<BybitLiquidation>>(internalData);
+                var desResult = Deserialize<BybitLiquidation>(internalData);
                 if (!desResult)
                 {
                     _logger.Log(LogLevel.Warning, $"Failed to deserialize {nameof(BybitLiquidation)} object: " + desResult.Error);

--- a/ByBit.Net/Interfaces/Clients/V5/IBybitSocketClientLinearApi.cs
+++ b/ByBit.Net/Interfaces/Clients/V5/IBybitSocketClientLinearApi.cs
@@ -41,7 +41,7 @@ namespace Bybit.Net.Interfaces.Clients.V5
         /// <param name="handler">Data handler</param>
         /// <param name="ct">Cancellation token. Cancelling will cancel the subscription</param>
         /// <returns></returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToLiquidationUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<IEnumerable<BybitLiquidation>>> handler, CancellationToken ct = default);
+        Task<CallResult<UpdateSubscription>> SubscribeToLiquidationUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<BybitLiquidation>> handler, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to liquidation updates
@@ -51,7 +51,7 @@ namespace Bybit.Net.Interfaces.Clients.V5
         /// <param name="handler">Data handler</param>
         /// <param name="ct">Cancellation token. Cancelling will cancel the subscription</param>
         /// <returns></returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToLiquidationUpdatesAsync(string symbol, Action<DataEvent<IEnumerable<BybitLiquidation>>> handler, CancellationToken ct = default);
+        Task<CallResult<UpdateSubscription>> SubscribeToLiquidationUpdatesAsync(string symbol, Action<DataEvent<BybitLiquidation>> handler, CancellationToken ct = default);
 
     }
 }

--- a/ByBit.Net/Interfaces/Clients/V5/IBybitSocketClientOptionApi.cs
+++ b/ByBit.Net/Interfaces/Clients/V5/IBybitSocketClientOptionApi.cs
@@ -41,7 +41,7 @@ namespace Bybit.Net.Interfaces.Clients.V5
         /// <param name="handler">Data handler</param>
         /// <param name="ct">Cancellation token. Cancelling will cancel the subscription</param>
         /// <returns></returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToLiquidationUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<IEnumerable<BybitLiquidation>>> handler, CancellationToken ct = default);
+        Task<CallResult<UpdateSubscription>> SubscribeToLiquidationUpdatesAsync(IEnumerable<string> symbols, Action<DataEvent<BybitLiquidation>> handler, CancellationToken ct = default);
 
         /// <summary>
         /// Subscribe to liquidation updates
@@ -51,7 +51,7 @@ namespace Bybit.Net.Interfaces.Clients.V5
         /// <param name="handler">Data handler</param>
         /// <param name="ct">Cancellation token. Cancelling will cancel the subscription</param>
         /// <returns></returns>
-        Task<CallResult<UpdateSubscription>> SubscribeToLiquidationUpdatesAsync(string symbol, Action<DataEvent<IEnumerable<BybitLiquidation>>> handler, CancellationToken ct = default);
+        Task<CallResult<UpdateSubscription>> SubscribeToLiquidationUpdatesAsync(string symbol, Action<DataEvent<BybitLiquidation>> handler, CancellationToken ct = default);
 
     }
 }


### PR DESCRIPTION
The Bybit result produces a single object.
https://bybit-exchange.github.io/docs/v5/websocket/public/liquidation

First time i'm creating a pull request, so if anything is wrong/missing please point it out.