### PR TITLE
Fix GetSpotSymbolsAsync request missing parameters

### DIFF
--- a/ByBit.Net/Clients/V5/BybitRestClientApiExchangeData.cs
+++ b/ByBit.Net/Clients/V5/BybitRestClientApiExchangeData.cs
@@ -136,14 +136,15 @@ namespace Bybit.Net.Clients.V5
         #region Get Spot symbols
 
         /// <inheritdoc />
-        public async Task<WebCallResult<BybitResponse<BybitSpotSymbol>>> GetSpotSymbolsAsync(string? symbol = null, CancellationToken ct = default)
+        public async Task<WebCallResult<BybitResponse<BybitSpotSymbol>>> GetSpotSymbolsAsync(string? symbol = null, int? limit = null, string? cursor = null, CancellationToken ct = default)
         {
             var parameters = new Dictionary<string, object>()
             {
                 { "category", EnumConverter.GetString(Category.Spot) }
             };
             parameters.AddOptionalParameter("symbol", symbol);
-
+            parameters.AddOptionalParameter("limit", limit);
+            parameters.AddOptionalParameter("cursor", cursor);
             return await _baseClient.SendRequestAsync<BybitResponse<BybitSpotSymbol>>(_baseClient.GetUrl("v5/market/instruments-info"), HttpMethod.Get, ct, parameters).ConfigureAwait(false);
         }
 

--- a/ByBit.Net/Interfaces/Clients/V5/IBybitRestClientApiExchangeData.cs
+++ b/ByBit.Net/Interfaces/Clients/V5/IBybitRestClientApiExchangeData.cs
@@ -228,9 +228,11 @@ namespace Bybit.Net.Interfaces.Clients.V5
         /// <para><a href="https://bybit-exchange.github.io/docs/v5/market/instrument" /></para>
         /// </summary>
         /// <param name="symbol">Filter by symbol</param>
+        /// <param name="limit">Number of results per page</param>
+        /// <param name="cursor">Pagination cursor</param>
         /// <param name="ct">Cancellation token</param>
         /// <returns></returns>
-        Task<WebCallResult<BybitResponse<BybitSpotSymbol>>> GetSpotSymbolsAsync(string? symbol = null, CancellationToken ct = default);
+        Task<WebCallResult<BybitResponse<BybitSpotSymbol>>> GetSpotSymbolsAsync(string? symbol = null, int? limit = null, string? cursor = null, CancellationToken ct = default);
 
         /// <summary>
         /// Spot tickers


### PR DESCRIPTION
Small fixes for V5 api. GetSpotSymbolsAsync misses few parameters.