### PR TITLE
Fix Bug in Demo Trading: Update Server Time Endpoint to API v5

### DIFF
--- a/ByBit.Net/Clients/DerivativesApi/BybitRestClientDerivativesApiExchangeData.cs
+++ b/ByBit.Net/Clients/DerivativesApi/BybitRestClientDerivativesApiExchangeData.cs
@@ -253,7 +253,7 @@ namespace Bybit.Net.Clients.DerivativesApi
         /// <inheritdoc />
         public async Task<WebCallResult<DateTime>> GetServerTimeAsync(CancellationToken ct = default)
         {
-            var result = await _baseClient.SendRequestWrapperAsync<BybitDerivativesServerTime>(_baseClient.GetUrl("/v3/public/time"), HttpMethod.Get, ct, null).ConfigureAwait(false);
+            var result = await _baseClient.SendRequestWrapperAsync<BybitDerivativesServerTime>(_baseClient.GetUrl("/v5/market/time"), HttpMethod.Get, ct, null).ConfigureAwait(false);
             if (!result)
                 return result.As<DateTime>(default);
 

--- a/ByBit.Net/Clients/V5/BybitRestClientApiExchangeData.cs
+++ b/ByBit.Net/Clients/V5/BybitRestClientApiExchangeData.cs
@@ -49,7 +49,7 @@ namespace Bybit.Net.Clients.V5
         public async Task<WebCallResult<BybitTime>> GetServerTimeAsync(CancellationToken ct = default)
         {
             // V5 doesn't have it's own server time endpoint (yet)
-            return await _baseClient.SendRequestAsync<BybitTime>(_baseClient.GetUrl("v3/public/time"), HttpMethod.Get, ct, null).ConfigureAwait(false);
+            return await _baseClient.SendRequestAsync<BybitTime>(_baseClient.GetUrl("/v5/market/time"), HttpMethod.Get, ct, null).ConfigureAwait(false);
         }
 
         #endregion


### PR DESCRIPTION
This pull request addresses a bug in the Demo Trading system where the endpoint to retrieve the Server Time was using the outdated v3 API. Since the Demo Trading API has shifted to version 5, the endpoint has been updated to ensure compatibility and proper functioning.

Changes Made
- Replaced the Server Time endpoint from v3 to v5.

This change should resolve any issues with retrieving the Server Time and align the Demo Trading API with the current version. Let me know if any additional tests or reviews are needed.