### PR TITLE
Added support for the OrderPriceLimit web socket stream

### DIFF
--- a/ByBit.Net/Clients/V5/BybitSocketClientBaseApi.cs
+++ b/ByBit.Net/Clients/V5/BybitSocketClientBaseApi.cs
@@ -89,5 +89,15 @@ namespace Bybit.Net.Clients.V5
             var subscription = new BybitSubscription<BybitLiquidationUpdate[]>(_logger, symbols.Select(x => $"allLiquidation.{x}").ToArray(), handler);
             return await SubscribeAsync(BaseAddress + _baseEndpoint, subscription, ct).ConfigureAwait(false);
         }
+
+        
+        public Task<CallResult<UpdateSubscription>> SubscribeToPriceLimitAsync(string symbol, Action<DataEvent<BybitOrderPriceLimit>> handler, CancellationToken ct = default)
+            => SubscribeToPriceLimitAsync(new string[] { symbol }, handler, ct);
+
+        public async Task<CallResult<UpdateSubscription>> SubscribeToPriceLimitAsync(IEnumerable<string> symbols, Action<DataEvent<BybitOrderPriceLimit>> handler, CancellationToken ct = default)
+        {
+            var subscription = new BybitSubscription<BybitOrderPriceLimit>(_logger, symbols.Select(s => $"priceLimit.{s}").ToArray(), handler);
+            return await SubscribeAsync(BaseAddress + _baseEndpoint, subscription, ct).ConfigureAwait(false);
+        }
     }
 }

--- a/ByBit.Net/Converters/BybitSourceGenerationContext.cs
+++ b/ByBit.Net/Converters/BybitSourceGenerationContext.cs
@@ -81,6 +81,7 @@ namespace Bybit.Net.Converters
     [JsonSerializable(typeof(BybitSpotSocketEvent<BybitGreeks[]>))]
     [JsonSerializable(typeof(BybitSpotSocketEvent<BybitSpreadTickerUpdate>))]
     [JsonSerializable(typeof(BybitSpotSocketEvent<BybitInsuranceUpdate[]>))]
+    [JsonSerializable(typeof(BybitSpotSocketEvent<BybitOrderPriceLimit>))]
 
     [JsonSerializable(typeof(BybitResult<BybitResult>))]
     [JsonSerializable(typeof(BybitResult<BybitTakeProfitStopLossMode>))]

--- a/ByBit.Net/Interfaces/Clients/V5/IBybitSocketClientBaseApi.cs
+++ b/ByBit.Net/Interfaces/Clients/V5/IBybitSocketClientBaseApi.cs
@@ -59,6 +59,24 @@ namespace Bybit.Net.Interfaces.Clients.V5
         /// <returns></returns>
         Task<CallResult<UpdateSubscription>> SubscribeToOrderbookUpdatesAsync(string symbol, int depth, Action<DataEvent<BybitOrderbook>> updateHandler, CancellationToken ct = default);
 
-        
+        /// <summary>
+        /// Subscribe to price limit updates
+        /// <para><a href="https://bybit-exchange.github.io/docs/v5/websocket/public/order-price-limit" /></para>
+        /// </summary>
+        /// <param name="symbols">The symbol to subscribe, for example `ETHUSDT`</param>
+        /// <param name="handler">Data handler</param>
+        /// <param name="ct">Cancellation token. Cancelling will cancel the subscription</param>
+        /// <returns></returns>
+        Task<CallResult<UpdateSubscription>> SubscribeToPriceLimitAsync(IEnumerable<string> symbols, Action<DataEvent<BybitOrderPriceLimit>> handler, CancellationToken ct = default);
+
+        /// <summary>
+        /// Subscribe to price limit updates
+        /// <para><a href="https://bybit-exchange.github.io/docs/v5/websocket/public/order-price-limit" /></para>
+        /// </summary>
+        /// <param name="symbol">The symbol to subscribe, for example `ETHUSDT`</param>
+        /// <param name="handler">Data handler</param>
+        /// <param name="ct">Cancellation token. Cancelling will cancel the subscription</param>
+        /// <returns></returns>
+        Task<CallResult<UpdateSubscription>> SubscribeToPriceLimitAsync(string symbol, Action<DataEvent<BybitOrderPriceLimit>> handler, CancellationToken ct = default);
     }
 }

--- a/ByBit.Net/Interfaces/Clients/V5/IBybitSocketClientOptionApi.cs
+++ b/ByBit.Net/Interfaces/Clients/V5/IBybitSocketClientOptionApi.cs
@@ -98,5 +98,26 @@ namespace Bybit.Net.Interfaces.Clients.V5
         /// <param name="ct">Cancellation token. Cancelling will cancel the subscription</param>
         /// <returns></returns>
         Task<CallResult<UpdateSubscription>> SubscribeToTradeUpdatesAsync(string symbol, Action<DataEvent<BybitOptionTrade[]>> handler, CancellationToken ct = default);
+
+
+        /// <summary>
+        /// Subscribe to price limit updates
+        /// <para><a href="https://bybit-exchange.github.io/docs/v5/websocket/public/order-price-limit" /></para>
+        /// </summary>
+        /// <param name="symbols">The symbol to subscribe, for example `ETHUSDT`</param>
+        /// <param name="handler">Data handler</param>
+        /// <param name="ct">Cancellation token. Cancelling will cancel the subscription</param>
+        /// <returns></returns>
+        Task<CallResult<UpdateSubscription>> SubscribeToPriceLimitAsync(IEnumerable<string> symbols, Action<DataEvent<BybitOrderPriceLimit>> handler, CancellationToken ct = default);
+
+        /// <summary>
+        /// Subscribe to price limit updates
+        /// <para><a href="https://bybit-exchange.github.io/docs/v5/websocket/public/order-price-limit" /></para>
+        /// </summary>
+        /// <param name="symbol">The symbol to subscribe, for example `ETHUSDT`</param>
+        /// <param name="handler">Data handler</param>
+        /// <param name="ct">Cancellation token. Cancelling will cancel the subscription</param>
+        /// <returns></returns>
+        Task<CallResult<UpdateSubscription>> SubscribeToPriceLimitAsync(string symbol, Action<DataEvent<BybitOrderPriceLimit>> handler, CancellationToken ct = default);
     }
 }

--- a/ByBit.Net/Objects/Models/V5/BybitSpotSymbol.cs
+++ b/ByBit.Net/Objects/Models/V5/BybitSpotSymbol.cs
@@ -84,6 +84,31 @@ namespace Bybit.Net.Objects.Models.V5
     }
 
     /// <summary>
+    /// Current price limits that an order has.
+    /// </summary>
+    [SerializationModel]
+    public record BybitOrderPriceLimit
+    {
+        /// <summary>
+        /// Symbol name
+        /// </summary>
+        [JsonPropertyName("symbol")]
+        public string Symbol { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Highest possible bid price
+        /// </summary>
+        [JsonPropertyName("buyLmt")]
+        public decimal BuyLimit { get; set; }
+
+        /// <summary>
+        /// Lowest possible Ask Price
+        /// </summary>
+        [JsonPropertyName("sellLmt")]
+        public decimal SellLimit { get; set; }
+    }
+
+    /// <summary>
     /// Lot size filter info
     /// </summary>
     [SerializationModel]

--- a/Bybit.UnitTests/SocketSubscriptionTests.cs
+++ b/Bybit.UnitTests/SocketSubscriptionTests.cs
@@ -23,6 +23,7 @@ namespace Bybit.Net.UnitTests
             await tester.ValidateAsync<BybitLeveragedTokenTicker>((client, handler) => client.V5SpotApi.SubscribeToLeveragedTokenTickerUpdatesAsync("BTCUSDT", handler), "LeveragedTicker");
             await tester.ValidateAsync<BybitLeveragedTokenNav>((client, handler) => client.V5SpotApi.SubscribeToLeveragedTokenNavUpdatesAsync("BTCUSDT", handler), "LeveragedNav");
             await tester.ValidateAsync<BybitTrade[]>((client, handler) => client.V5SpotApi.SubscribeToTradeUpdatesAsync("BTCUSDT", handler), "Trades");
+            await tester.ValidateAsync<BybitOrderPriceLimit>((client, handler) => client.V5SpotApi.SubscribeToPriceLimitAsync("BTCUSDT", handler), "PriceLimit");
         }
 
         [Test]
@@ -50,6 +51,7 @@ namespace Bybit.Net.UnitTests
             await tester.ValidateAsync<BybitLinearTickerUpdate>((client, handler) => client.V5LinearApi.SubscribeToTickerUpdatesAsync("BTCUSDT", handler), "Ticker");
             await tester.ValidateAsync<BybitTrade[]>((client, handler) => client.V5LinearApi.SubscribeToTradeUpdatesAsync("BTCUSDT", handler), "Trades");
             await tester.ValidateAsync<BybitLiquidationUpdate[]>((client, handler) => client.V5LinearApi.SubscribeToAllLiquidationUpdatesAsync("ETHUSDT", handler), "Liquidations");
+            await tester.ValidateAsync<BybitOrderPriceLimit>((client, handler) => client.V5LinearApi.SubscribeToPriceLimitAsync("BTCUSDT", handler), "PriceLimit");
         }
 
         [Test]

--- a/Bybit.UnitTests/Subscriptions/V5/Linear/PriceLimit.txt
+++ b/Bybit.UnitTests/Subscriptions/V5/Linear/PriceLimit.txt
@@ -1,0 +1,12 @@
+> { "req_id": "|1|", "op": "subscribe", "args": [ "priceLimit.BTCUSDT" ] }
+< { "success": true, "ret_msg": "subscribe", "conn_id": "69b552d7-f8cf-46bc-a6ee-c6ed331ce668", "req_id": "|1|", "op": "subscribe" }
+= 
+{
+	"topic": "priceLimit.BTCUSDT",
+	"data": {
+		"symbol": "BTCUSDT",
+		"buyLmt": "2.436558",
+		"sellLmt": "2.118747"
+	},
+	"ts": 1750963471934
+}

--- a/Bybit.UnitTests/Subscriptions/V5/Spot/PriceLimit.txt
+++ b/Bybit.UnitTests/Subscriptions/V5/Spot/PriceLimit.txt
@@ -1,0 +1,12 @@
+> { "req_id": "|1|", "op": "subscribe", "args": [ "priceLimit.BTCUSDT" ] }
+< { "success": true, "ret_msg": "subscribe", "conn_id": "79b552d7-f8cf-46bc-a6ee-c6ed331ce668", "req_id": "|1|", "op": "subscribe" }
+= 
+{
+	"topic": "priceLimit.BTCUSDT",
+	"data": {
+		"symbol": "BTCUSDT",
+		"buyLmt": "2.436558",
+		"sellLmt": "2.118747"
+	},
+	"ts": 1750963471934
+}


### PR DESCRIPTION
Hi Jan,

I've added support for the OrderPriceLimit web socket stream: https://bybit-exchange.github.io/docs/v5/websocket/public/order-price-limit.

**Changes**
- Added subscribe methods to BybitSocketClientBaseApi
- Added new model in BybitSpotSymbol.cs that contains the highest and lowest possible order prices for that moment
- Updated tests